### PR TITLE
Remove hat election, canCall checks approvals directly

### DIFF
--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -11,7 +11,6 @@ contract DssChief is DSAuth, DSAuthority {
     TokenLike                       public gov;         // MKR gov token
     uint256                         public supply;      // Total MKR locked
     uint256                         public ttl;         // MKR locked expiration time (admin param)
-    address                         public hat;         // Elected Candidate
     mapping(address => address)     public votes;       // Voter => Candidate
     mapping(address => uint256)     public approvals;   // Candidate => Amount of votes
     mapping(address => uint256)     public deposits;    // Voter => Voting power
@@ -75,16 +74,7 @@ contract DssChief is DSAuth, DSAuthority {
         last[msg.sender] = now;
     }
 
-    function lift(address whom) external {
-        // Verify the actual candidate has more than half of total supply of locked MKR
-        require(approvals[whom] > supply / 2, "DssChief/not-enough-voting-power");
-        // Elect new candidate
-        hat = whom;
-        // Signal this account has been active and renew expiration time
-        last[msg.sender] = now;
-    }
-
     function canCall(address caller, address, bytes4) public view returns (bool ok) {
-        ok = caller == hat;
+        ok = approvals[caller] > supply / 2;
     }
 }

--- a/src/DssChief.t.sol
+++ b/src/DssChief.t.sol
@@ -49,10 +49,6 @@ contract ChiefUser {
         chief.vote(whom);
     }
 
-    function doLift(address whom) public {
-        chief.lift(whom);
-    }
-
     function doLock(uint wad) public {
         chief.lock(wad);
     }
@@ -179,8 +175,6 @@ contract DssChiefTest is DSTest {
         user2.doLock(user2InitialBalance);
 
         user2.doVote(candidate1);
-        chief.lift(candidate1);
-        assertEq(candidate1, chief.hat());
         CandidateUser(candidate1).doSysTest();
     }
 
@@ -188,8 +182,8 @@ contract DssChiefTest is DSTest {
         CandidateUser(candidate1).doSysTest();
     }
 
-    function _tryLift(address usr) internal returns (bool ok) {
-        (ok,) = address(chief).call(abi.encodeWithSignature("lift(address)", usr));
+    function _trySysTest(address usr) internal returns (bool ok) {
+        (ok,) = address(usr).call(abi.encodeWithSignature("doSysTest()"));
     }
 
     function test_lift() public {
@@ -203,26 +197,26 @@ contract DssChiefTest is DSTest {
         assertEq(chief.approvals(candidate1), 350 ether);
         assertEq(chief.approvals(candidate2), 250 ether);
         assertEq(chief.approvals(candidate3), 200 ether);
-        assertTrue(!_tryLift(candidate1)); // candidate1 ~ 43% => can't be elected
+        assertTrue(!_trySysTest(candidate1)); // candidate1 ~ 43% => can't execute
 
         user3.doVote(candidate2);
         assertEq(chief.approvals(candidate1), 350 ether);
         assertEq(chief.approvals(candidate2), 450 ether);
         assertEq(chief.approvals(candidate3), 0);
-        assertTrue(_tryLift(candidate2)); // candidate2 ~ 56% => can be elected
+        assertTrue(_trySysTest(candidate2)); // candidate2 ~ 56% => can execute
 
         hevm.warp(1);
         user3.doFree(user3, 100 ether);
         assertEq(chief.approvals(candidate1), 350 ether);
         assertEq(chief.approvals(candidate2), 350 ether);
         assertEq(chief.approvals(candidate3), 0);
-        assertTrue(!_tryLift(candidate2)); // candidate2 = 50% => can't be elected
+        assertTrue(!_trySysTest(candidate2)); // candidate2 = 50% => can't execute
 
         user3.doLock(1);
         assertEq(chief.approvals(candidate1), 350 ether);
         assertEq(chief.approvals(candidate2), 350 ether + 1);
         assertEq(chief.approvals(candidate3), 0);
-        assertTrue(_tryLift(candidate2)); // candidate2 > 50% => can be elected
+        assertTrue(_trySysTest(candidate2)); // candidate2 > 50% => can execute
     }
 
     function test_free_other_user() public {


### PR DESCRIPTION
`hat`less version.
It checks `approvals[caller] > supply / 2` directly in `canCall`.

Maybe negative side: It makes hard to determine which is the actual `hat`. However that is relative, the actual `hat` might not even be the most voted proposal giving a false safety.
Also we could keep track of the most voted proposal adding an extra operation in `lock`, `free` and `vote`. However there would be a conflict when two proposals have the same amount and also it would still hide the other proposals which might be very closed to the most voted.

Positive side:
- Removes an unnecessary operation.
- Leaves the path clean to go to multi voting proposal as removes the idea of one only "`hat`". Which btw I'm thinking to integrate soon in another PR.