### PR TITLE
Implement multiple voting

### DIFF
--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -8,13 +8,14 @@ contract TokenLike {
 }
 
 contract DssChief is DSAuth, DSAuthority {
-    TokenLike                       public gov;         // MKR gov token
-    uint256                         public supply;      // Total MKR locked
-    uint256                         public ttl;         // MKR locked expiration time (admin param)
-    mapping(address => address)     public votes;       // Voter => Candidate
-    mapping(address => uint256)     public approvals;   // Candidate => Amount of votes
-    mapping(address => uint256)     public deposits;    // Voter => Voting power
-    mapping(address => uint256)     public last;        // Last time executed
+    TokenLike                                           public gov;         // MKR gov token
+    uint256                                             public supply;      // Total MKR locked
+    uint256                                             public ttl;         // MKR locked expiration time (admin param)
+    mapping(address => mapping(address => uint256))     public votes;       // Voter => Candidate => Voted
+    mapping(address => uint256)                         public approvals;   // Candidate => Amount of votes
+    mapping(address => uint256)                         public deposits;    // Voter => Voting power
+    mapping(address => uint256)                         public count;       // Voter => Amount of candidates voted
+    mapping(address => uint256)                         public last;        // Last time executed
 
     function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x + y) >= x);
@@ -34,12 +35,12 @@ contract DssChief is DSAuth, DSAuthority {
     }
 
     function lock(uint256 wad) external {
+        // Can't lock more MKR if msg.sender is already voting candidates
+        require(count[msg.sender] == 0, "DssChief/existing-voted-candidates");
         // Pull collateral from sender's wallet
         gov.transferFrom(msg.sender, address(this), wad);
         // Increase amount deposited from sender
         deposits[msg.sender] = add(deposits[msg.sender], wad);
-        // Add new voting power to the actual voted candidate
-        approvals[votes[msg.sender]] = add(approvals[votes[msg.sender]], wad);
         // Increase total supply
         supply = add(supply, wad);
         // Signal this account has been active and renew expiration time
@@ -47,14 +48,14 @@ contract DssChief is DSAuth, DSAuthority {
     }
 
     function free(address usr, uint256 wad) external {
+        // Can't free MKR if usr is still voting candidates
+        require(count[usr] == 0, "DssChief/existing-voted-candidates");
         // Verify usr is sender or their voting power is already expired
-        require(usr == msg.sender || add(last[usr], ttl) < now , "DssChief/not-allowed-to-free");
+        require(usr == msg.sender || add(last[usr], ttl) < now, "DssChief/not-allowed-to-free");
         // Verify is not freeing on same block where another action happened (to avoid usage of flash loans)
         require(last[usr] < now, "DssChief/not-minimum-time-passed");
         // Decrease amount deposited from usr
         deposits[usr] = sub(deposits[usr], wad);
-        // Remove voting power from the actual voted candidate
-        approvals[votes[usr]] = sub(approvals[votes[usr]], wad);
         // Decrease total supply
         supply = sub(supply, wad);
         // Push token back to usr's wallet
@@ -64,12 +65,29 @@ contract DssChief is DSAuth, DSAuthority {
     }
 
     function vote(address whom) external {
-        // Remove voting power from the actual voted candidate
-        approvals[votes[msg.sender]] = sub(approvals[votes[msg.sender]], deposits[msg.sender]);
-        // Vote new candidate
-        votes[msg.sender] = whom;
-        // Add new voting power to the new candidate
+        // Check the whom candidate was not previously voted by msg.sender
+        require(votes[msg.sender][whom] == 0, "DssChief/candidate-already-voted");
+        // Mark candidate as voted by msg.sender
+        votes[msg.sender][whom] = 1;
+        // Add voting power to the candidate
         approvals[whom] = add(approvals[whom], deposits[msg.sender]);
+        // Increase the voting counter from msg.sender
+        count[msg.sender] = add(count[msg.sender], 1);
+        // Signal this account has been active and renew expiration time
+        last[msg.sender] = now;
+    }
+
+    function undo(address usr, address whom) external {
+        // Check the candidate whom is actually voted by usr
+        require(votes[usr][whom] == 1, "DssChief/candidate-not-voted");
+        // Verify usr is sender or their voting power is already expired
+        require(usr == msg.sender || add(last[usr], ttl) < now, "DssChief/not-allowed-to-undo");
+        // Mark candidate as no voted by usr
+        votes[usr][whom] = 0;
+        // Remove voting power from the candidate
+        approvals[whom] = sub(approvals[whom], deposits[usr]);
+        // Decrease the voting counter from usr
+        count[usr] = sub(count[usr], 1);
         // Signal this account has been active and renew expiration time
         last[msg.sender] = now;
     }

--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -60,6 +60,8 @@ contract DssChief is DSAuth, DSAuthority {
         supply = sub(supply, wad);
         // Push token back to usr's wallet
         gov.transfer(usr, wad);
+        // Clean storage if usr is not the sender (for gas refund)
+        if (usr != msg.sender) delete last[usr];
         // Signal this account has been active and renew expiration time
         last[msg.sender] = now;
     }

--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -82,7 +82,7 @@ contract DssChief is DSAuth, DSAuthority {
         require(votes[usr][whom] == 1, "DssChief/candidate-not-voted");
         // Verify usr is sender or their voting power is already expired
         require(usr == msg.sender || add(last[usr], ttl) < now, "DssChief/not-allowed-to-undo");
-        // Mark candidate as no voted by usr
+        // Mark candidate as not voted for by usr
         votes[usr][whom] = 0;
         // Remove voting power from the candidate
         approvals[whom] = sub(approvals[whom], deposits[usr]);


### PR DESCRIPTION
This is an implementation of multiple candidates voting.
This way a voter can vote `n` amount of candidates without any restriction, allowing to run multiple executive votes at the same time.
This implementation should be FV friendly, proxies can take care of the annoying of having to unvote for locking or freeing MKR.