### PR TITLE
Min first vote

### DIFF
--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -84,7 +84,10 @@ contract DssChief {
         require(votes[msg.sender][whom] == 0, "DssChief/candidate-already-voted");
         // If it's the first vote for this candidate, set the expiration time
         if (expirations[whom] == 0) {
-            require(deposits[msg.sender] >= min, "DssChief/not-minimum-amount");
+            // Check min is set to 0 or
+            // users deposits are >= than min value + is not launching a vote on same block where another action happened (to avoid usage of flash loans)
+            require(min == 0 || deposits[msg.sender] >= min && last[msg.sender] < now, "DssChief/not-minimum-amount");
+            // Set expiration time
             expirations[whom] = add(now, end);
         }
         // Mark candidate as voted by msg.sender

--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -19,6 +19,7 @@ contract DssChief {
     uint256                                             public supply;      // Total MKR locked
     uint256                                             public ttl;         // MKR locked expiration time (admin param)
     uint256                                             public end;         // Duration of a candidate's validity in seconds (admin param)
+    uint256                                             public min;         // Min MKR stake for launching a vote (admin param)
     mapping(address => mapping(address => uint256))     public votes;       // Voter => Candidate => Voted
     mapping(address => uint256)                         public approvals;   // Candidate => Amount of votes
     mapping(address => uint256)                         public expirations; // Candidate => Expiration
@@ -42,6 +43,7 @@ contract DssChief {
     function file(bytes32 what, uint256 data) public auth {
         if (what == "ttl") ttl = data;
         else if (what == "end") end = data;
+        else if (what == "min") min = data;
         else revert("DssChief/file-unrecognized-param");
     }
 
@@ -82,6 +84,7 @@ contract DssChief {
         require(votes[msg.sender][whom] == 0, "DssChief/candidate-already-voted");
         // If it's the first vote for this candidate, set the expiration time
         if (expirations[whom] == 0) {
+            require(deposits[msg.sender] >= min, "DssChief/not-minimum-amount");
             expirations[whom] = add(now, end);
         }
         // Mark candidate as voted by msg.sender

--- a/src/DssChief.t.sol
+++ b/src/DssChief.t.sol
@@ -308,4 +308,20 @@ contract DssChiefTest is DSTest {
         hevm.warp(chief.ttl());
         user1.doFree(user3, user3InitialBalance);
     }
+
+    function test_min_first_vote() public {
+        chief.file("min", 50);
+        user3.doLock(50);
+        assertEq(chief.deposits(address(user3)), 50);
+        user3.doVote(candidate1);
+        user2.doLock(49);
+        assertEq(chief.deposits(address(user2)), 49);
+        user2.doVote(candidate1);
+    }
+
+    function testFail_min_first_vote() public {
+        chief.file("min", 50);
+        user3.doLock(49);
+        user3.doVote(candidate1);
+    }
 }

--- a/src/DssChief.t.sol
+++ b/src/DssChief.t.sol
@@ -309,19 +309,27 @@ contract DssChiefTest is DSTest {
         user1.doFree(user3, user3InitialBalance);
     }
 
-    function test_min_first_vote() public {
+    function test_first_vote_min() public {
         chief.file("min", 50);
         user3.doLock(50);
         assertEq(chief.deposits(address(user3)), 50);
+        hevm.warp(1);
         user3.doVote(candidate1);
         user2.doLock(49);
         assertEq(chief.deposits(address(user2)), 49);
         user2.doVote(candidate1);
     }
 
-    function testFail_min_first_vote() public {
+    function testFail_first_vote_not_min() public {
+        chief.file("min", 50);
+        user3.doLock(50);
+        user3.doVote(candidate1);
+    }
+
+    function testFail_first_vote_not_time() public {
         chief.file("min", 50);
         user3.doLock(49);
+        hevm.warp(1);
         user3.doVote(candidate1);
     }
 }


### PR DESCRIPTION
Require a minimum MKR stake to start a voting of a spell.
This may be a bit controversial but the system allows to set it to 0 effectively allowing everybody to start them. So might be nice to have it.