### PR TITLE
Plot to pause

### DIFF
--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -173,7 +173,7 @@ contract DssChief {
 
     function drop(address delay, address action) external {
         // Check enough MKR is voting address(0) => which means Governance is in emergency mode
-        require(approvals[address(0)] > mul(supply, post) / 100, "DssChief/not-enough-voting-power");
+        require(approvals[address(0)][address(0)] > mul(supply, post) / 100, "DssChief/not-enough-voting-power");
         // Drop action proposal
         plotted[delay][action] = 0;
         DelayLike(delay).drop(action);

--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -150,7 +150,7 @@ contract DssChief {
 
     function plot(address pause, address action) external {
         // Generate hash pause/action
-        bytes32 whom = keccak256(abi.encodePacked(pause, proposal));
+        bytes32 whom = keccak256(abi.encodePacked(pause, action));
         // Check enough MKR is voting this proposal and it's not already expired
         require(approvals[whom] > mul(supply, post) / 100, "DssChief/not-enough-voting-power");
         require(now <= expirations[whom], "vote-expired");
@@ -166,7 +166,7 @@ contract DssChief {
         // Check enough MKR is voting address(0) => which means Governance is in emergency mode
         require(approvals[address(0)] > mul(supply, post) / 100, "DssChief/not-enough-voting-power");
         // Generate hash pause/action
-        bytes32 whom = keccak256(abi.encodePacked(pause, proposal));
+        bytes32 whom = keccak256(abi.encodePacked(pause, action));
         // Drop action proposal
         PauseLike(pause).drop(action, abi.encodeWithSignature("execute()"), eta[whom]);
     }

--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -168,7 +168,7 @@ contract DssChief {
         require(plotted[delay][action] == 0, "DssChief/action-already-plotted");
         // Plot action proposal
         plotted[delay][action] = 1;
-        DelayLike(delay).plot(action, eta[delay][action]);
+        DelayLike(delay).plot(action);
     }
 
     function drop(address delay, address action) external {

--- a/src/DssDelay.sol
+++ b/src/DssDelay.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.5.12;
+
+contract DssDelay {
+    // --- Auth ---
+    mapping (address => uint256)    public wards;
+    function rely(address usr)      external wait { wards[usr] = 1; }
+    function deny(address usr)      external wait { wards[usr] = 0; }
+    modifier auth {
+        require(wards[msg.sender] == 1, "DssDelay/not-authorized");
+        _;
+    }
+    modifier wait {
+        require(msg.sender == address(this), "DssDelay/undelayed-call");
+        _;
+    }
+
+    uint256 public tic;
+    mapping (address => uint256) public plan;
+
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x + y) >= x);
+    }
+
+    function file(bytes32 what, uint256 data) public wait {
+        if (what == "tic") tic = data;
+        else revert("DssChief/file-unrecognized-param");
+    }
+
+    constructor(uint256 tic_) public {
+        tic = tic_;
+        wards[msg.sender] = 1;
+    }
+
+    function plot(address action) external auth returns (uint256 eta) {
+        eta = add(now, tic)
+        plan[action] = eta;
+    }
+
+    function drop(address action) external auth {
+        plan[action] = 0;
+    }
+
+    function exec(address action) external returns (bytes memory out) {
+        require(plan[action] != 0,   "DssDelay/not-plotted");
+        require(now >= plan[action], "DssDelay/not-delay-passed");
+
+        plan[action] = 0;
+        bool ok;
+        (ok, out) = action.delegatecall(abi.encodeWithSignature("execute()"););
+        require(ok, "DssDelay/delegatecall-error");
+    }
+}


### PR DESCRIPTION
I'm starting this PR to follow the discussion about transforming the `DssChief` from being an `authority` to a direct executor in the `Pause`.

This implementation considers the new `DssPause` will not have a `tag` for simplicity, thing that we can discuss if actually possible here: https://github.com/makerdao/dss-pause/issues/4

For dropping proposals the only viable idea that I had until now is having an "emergency" voting address (`address(0)`) which allows that any proposal can be `drop`ped. It is the only way I can see how Governance could react in less than 12 hours to a malicious massive spam attack of bad proposals.
Let me know your thoughts.