### PR TITLE
Add usage of gas reserve for ping/clear

### DIFF
--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -60,6 +60,7 @@ contract DssChief {
     // Auxiliar getters:
 
     function getVotes(uint256 id, address usr) external view returns (uint256) { return proposals[id].votes[usr]; }
+    function gasLength() external view returns(uint256) { return gas.length; }
 
 
     // Constants:
@@ -119,7 +120,8 @@ contract DssChief {
     function _burn() internal {
         uint256 l = gas.length;
         for (uint256 i = l - 1; i >= l - 50; i --) {
-            delete gas[i];
+            delete gas[i]; // TODO: Verify if this is necessary
+            gas.pop();
         }
     }
 

--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -112,15 +112,15 @@ contract DssChief {
     }
 
     function _mint() internal {
-        for (uint256 i = 0; i < 50; i ++) {
+        for (uint256 i = 0; i < 50; i++) {
             gas.push(1);
         }
     }
 
     function _burn() internal {
         uint256 l = gas.length;
-        for (uint256 i = l - 1; i >= l - 50; i --) {
-            delete gas[i]; // TODO: Verify if this is necessary
+        for (uint256 i = 1; i <= 50; i++) {
+            delete gas[l - i]; // TODO: Verify if this is necessary
             gas.pop();
         }
     }

--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -38,6 +38,7 @@ contract DssChief {
     mapping(address => uint256)                      public wards;         // Authorized addresses
     uint256                                          public live;          // System liveness
     TokenLike                                        public gov;           // MKR gov token
+    uint256[]                                        public gas;           // Gas storage reserve
     uint256                                          public ttl;           // MKR locked expiration time (admin param)
     uint256                                          public tic;           // Min time after making a proposal for a second one or freeing MKR (admin param)
     uint256                                          public end;           // Duration of a candidate's validity in seconds (admin param)
@@ -106,6 +107,19 @@ contract DssChief {
         } else {
             snapshotsNum[usr] = num = _add(num, 1);
             snapshots[usr][num] = Snapshot(block.number, wad);
+        }
+    }
+
+    function _mint() internal {
+        for (uint256 i = 0; i < 50; i ++) {
+            gas.push(1);
+        }
+    }
+
+    function _burn() internal {
+        uint256 l = gas.length;
+        for (uint256 i = l - 1; i >= l - 50; i --) {
+            delete gas[i];
         }
     }
 
@@ -251,6 +265,9 @@ contract DssChief {
 
         // Save snapshot
         _save(usr, 0);
+
+        // Burn gas storage reserve (refund for caller)
+        _burn();
     }
 
     function ping() external warm {
@@ -267,6 +284,9 @@ contract DssChief {
 
         // Save snapshot
         _save(msg.sender, r);
+
+        // Mint gas storage reserve
+        _mint();
     }
 
     function launch() external warm {

--- a/src/DssChief.sol
+++ b/src/DssChief.sol
@@ -39,11 +39,7 @@ contract DssChief {
     uint256                                          public live;          // System liveness
     TokenLike                                        public gov;           // MKR gov token
     uint256[]                                        public gas;           // Gas storage reserve
-    uint256                                          public ttl;           // MKR locked expiration time (admin param)
-    uint256                                          public tic;           // Min time after making a proposal for a second one or freeing MKR (admin param)
-    uint256                                          public end;           // Duration of a candidate's validity in seconds (admin param)
-    uint256                                          public min;           // Min MKR stake for launching a vote (admin param)
-    uint256                                          public post;          // Min % of total locked MKR to approve a proposal (admin param)
+    mapping(address => uint256)                      public gasOwners;     // User => Gas staked
     mapping(address => uint256)                      public deposits;      // User => MKR deposited
     mapping(address => address)                      public delegation;    // User => Delegated User
     mapping(address => uint256)                      public rights;        // User => Voting rights
@@ -55,9 +51,17 @@ contract DssChief {
     mapping(uint256 => Proposal)                     public proposals;     // Proposal Id => Proposal Info
     mapping(address => uint256)                      public snapshotsNum;  // User => Amount of snapshots
     mapping(address => mapping(uint256 => Snapshot)) public snapshots;     // User => Index => Snapshot
+    // Admin params
+    uint256                                          public ttl;           // MKR locked expiration time
+    uint256                                          public tic;           // Min time after making a proposal for a second one or freeing MKR
+    uint256                                          public end;           // Duration of a candidate's validity in seconds
+    uint256                                          public min;           // Min MKR stake for launching a vote
+    uint256                                          public post;          // Min % of total locked MKR to approve a proposal
+    uint256                                          public stake;         // Amount of gas to stake when executing ping
+    //
 
 
-    // Auxiliar getters:
+    // Extra getters:
 
     function getVotes(uint256 id, address usr) external view returns (uint256) { return proposals[id].votes[usr]; }
     function gasLength() external view returns(uint256) { return gas.length; }
@@ -111,18 +115,20 @@ contract DssChief {
         }
     }
 
-    function _mint() internal {
-        for (uint256 i = 0; i < 50; i++) {
+    function _mint(address usr) internal {
+        for (uint256 i = 0; i < stake; i++) {
             gas.push(1);
         }
+        gasOwners[usr] = stake;
     }
 
-    function _burn() internal {
+    function _burn(address usr) internal {
         uint256 l = gas.length;
-        for (uint256 i = 1; i <= 50; i++) {
+        for (uint256 i = 1; i <= gasOwners[usr]; i++) {
             delete gas[l - i]; // TODO: Verify if this is necessary
             gas.pop();
         }
+        gasOwners[usr] = 0;
     }
 
     function _getUserRights(address usr, uint256 index, uint256 blockNum) internal view returns (uint256 amount) {
@@ -159,6 +165,7 @@ contract DssChief {
         else if (what == "tic") tic = data; // TODO: Define if we want to place a safe max time
         else if (what == "end") end = data;
         else if (what == "min") min = data;
+        else if (what == "stake") stake = data;
         else if (what == "post") {
             require(data >= MIN_POST && data <= MAX_POST, "DssChief/post-not-safe-range");
             post = data;
@@ -269,7 +276,7 @@ contract DssChief {
         _save(usr, 0);
 
         // Burn gas storage reserve (refund for caller)
-        _burn();
+        _burn(usr);
     }
 
     function ping() external warm {
@@ -288,7 +295,7 @@ contract DssChief {
         _save(msg.sender, r);
 
         // Mint gas storage reserve
-        _mint();
+        _mint(msg.sender);
     }
 
     function launch() external warm {

--- a/src/DssChief.t.sol
+++ b/src/DssChief.t.sol
@@ -491,7 +491,7 @@ contract DssChiefTest is DSTest {
         user3.doPing();
         uint256 length = chief.gasLength();
         assertEq(length, 150);
-        _warp(60 days / 15 + 1);
+        _warp(chief.ttl() / 15 + 1);
 
         chief.clear(address(user3));
         length = chief.gasLength();

--- a/src/DssChief.t.sol
+++ b/src/DssChief.t.sol
@@ -466,4 +466,42 @@ contract DssChiefTest is DSTest {
     function testFail_set_post_over_boundary() public {
         chief.file("post", chief.MAX_POST() + 1);
     }
+
+    function test_mint() public {
+        uint256 length = chief.gasLength();
+        assertEq(length, 0);
+        user1.doPing();
+        length = chief.gasLength();
+        assertEq(length, 50);
+        user2.doPing();
+        length = chief.gasLength();
+        assertEq(length, 100);
+        user3.doPing();
+        length = chief.gasLength();
+        assertEq(length, 150);
+
+        for(uint256 i = 0; i < 150; i++) {
+            assertEq(chief.gas(i), 1);
+        }
+    }
+
+    function test_burn() public {
+        user1.doPing();
+        user2.doPing();
+        user3.doPing();
+        uint256 length = chief.gasLength();
+        assertEq(length, 150);
+        _warp(60 days / 15 + 1);
+
+        chief.clear(address(user3));
+        length = chief.gasLength();
+        assertEq(length, 100);
+
+        for(uint256 i = 0; i < 100; i++) {
+            assertEq(chief.gas(i), 1);
+        }
+        // for(uint256 i = 100; i < 150; i++) {
+        //     assertEq(chief.gas(i), 0);
+        // }
+    }
 }

--- a/src/DssChief.t.sol
+++ b/src/DssChief.t.sol
@@ -157,7 +157,8 @@ contract DssChiefTest is DSTest {
         chief = new DssChief(address(gov));
         chief.file("ttl", 30 days);
         chief.file("end", 7 days);
-        chief.file("post", 50);
+        chief.file("post", 50); // 50%
+        chief.file("stake", 50); // 50 slots of storage
 
         exec12 = address(new ChiefExec(address(chief), 12 hours));
         exec0 = address(new ChiefExec(address(chief), 0));
@@ -468,17 +469,13 @@ contract DssChiefTest is DSTest {
     }
 
     function test_mint() public {
-        uint256 length = chief.gasLength();
-        assertEq(length, 0);
+        assertEq(chief.gasLength(), 0);
         user1.doPing();
-        length = chief.gasLength();
-        assertEq(length, 50);
+        assertEq(chief.gasLength(), 50);
         user2.doPing();
-        length = chief.gasLength();
-        assertEq(length, 100);
+        assertEq(chief.gasLength(), 100);
         user3.doPing();
-        length = chief.gasLength();
-        assertEq(length, 150);
+        assertEq(chief.gasLength(), 150);
 
         for(uint256 i = 0; i < 150; i++) {
             assertEq(chief.gas(i), 1);
@@ -489,13 +486,11 @@ contract DssChiefTest is DSTest {
         user1.doPing();
         user2.doPing();
         user3.doPing();
-        uint256 length = chief.gasLength();
-        assertEq(length, 150);
+        assertEq(chief.gasLength(), 150);
         _warp(chief.ttl() / 15 + 1);
 
         chief.clear(address(user3));
-        length = chief.gasLength();
-        assertEq(length, 100);
+        assertEq(chief.gasLength(), 100);
 
         for(uint256 i = 0; i < 100; i++) {
             assertEq(chief.gas(i), 1);
@@ -503,5 +498,29 @@ contract DssChiefTest is DSTest {
         // for(uint256 i = 100; i < 150; i++) {
         //     assertEq(chief.gas(i), 0);
         // }
+    }
+
+    function test_mint_burn_different_amounts() public {
+        assertEq(chief.gasLength(), 0);
+        user1.doPing();
+        assertEq(chief.gasLength(), 50);
+        user2.doPing();
+        assertEq(chief.gasLength(), 100);
+
+        chief.file("stake", 30);
+
+        user3.doPing();
+        assertEq(chief.gasLength(), 130);
+
+        _warp(chief.ttl() / 15 + 1);
+
+        chief.clear(address(user2));
+        assertEq(chief.gasLength(), 80);
+
+        chief.clear(address(user3));
+        assertEq(chief.gasLength(), 50);
+
+        chief.clear(address(user1));
+        assertEq(chief.gasLength(), 0);
     }
 }


### PR DESCRIPTION
Super simple first proposal to give incentives to the `clear` function. This can probably be more gas efficient using assembly and we could also change the logic creating contracts and destructing them instead of storage (like gas token v2). This is just a first idea of how it would be.

If we move on using storage we might want to make the number of slots manageable by governance. The only problem with that is it will require some record of how much gas has been staked on each `ping` or keep the general accumulator but after some time there might not be more gas to refund (if the value decreased over time).