### PR TITLE
DRAFT Layer 2 Delegate Logic

### DIFF
--- a/src/DssGov.t.sol
+++ b/src/DssGov.t.sol
@@ -92,6 +92,10 @@ contract GovUser {
     function doVote(uint256 proposal, uint256 sId, uint256 wad) public {
         gov.vote(proposal, sId, wad);
     }
+
+    function doClear(address usr) public {
+        gov.clear(usr);
+    }
 }
 
 contract ActionProposal {
@@ -349,6 +353,15 @@ contract DssGovTest is DSTest {
         user1.doDelegate(address(user1), address(user1));
         gov.launch();
         user1.doFree(100000 ether);
+    }
+
+    function _launch_L2() internal {
+        user1.doLock(100000 ether);
+        user1.doPing();
+        gov.addLayerTwoDelegate(address(user2));
+        user1.doDelegate(address(user1), address(user2));
+        user2.doPing();
+        gov.launch();
     }
 
     function test_propose() public {
@@ -660,5 +673,39 @@ contract DssGovTest is DSTest {
         user3.doPropose(exec12, action1);
         user3.doPropose(exec12, action1);
         user3.doPropose(exec12, action1);
+    }
+
+    function test_remove_L2_delegation() public {
+        _launch_L2();
+        user2.doDelegate(address(user1), address(0));
+        assertEq(gov.delegates(address(user1)), address(0));
+    }
+
+    function testFail_remove_L2_delegation() public {
+        _launch_L2();
+        user1.doDelegate(address(user1), address(0));
+    }
+
+    function test_remove_L2_delegate_and_free() public {
+        _launch_L2();
+        user2.doDelegate(address(user1), address(0));
+        user1.doFree(10 ether);
+    }
+
+    function testFail_free_L2() public {
+        _launch_L2();
+        user1.doFree(10 ether);
+    }
+
+    function test_add_L2_delegate() public {
+        gov.addLayerTwoDelegate(address(user1));
+        assertEq(gov.layerTwoDelegates(address(user1)), 1);
+    }
+
+    function test_remove_L2_delegate() public {
+        gov.addLayerTwoDelegate(address(user1));
+        assertEq(gov.layerTwoDelegates(address(user1)), 1);
+        gov.removeLayerTwoDelegate(address(user1));
+        assertEq(gov.layerTwoDelegates(address(user1)), 0);
     }
 }


### PR DESCRIPTION
Context: After talking with starkware, there was concern about users being able to change their voting rights on L1 while L2 was unaware of the changes.

This solution adds a new mapping of addresses called `layerTwoDelegates`. These delegates get a few special logic options. 

When delegated to a L2 contract, we do not allow users delegation to be changed on L1 unless that contract is the one calling `delegate`.
We do not allow users to call `free` until they have removed their delegation to a layer two delegate. 

These two changes means it is **required** that all L2s offer a trustless way to change delegation.

Considerations:
Should we enforce that `layerTwoDelegation` addresses are not EOAs?
Do we need special `clear` logic for them? I do not think so