### PR TITLE
Implement callback for some delegation contracts as L2 voting systems

### DIFF
--- a/src/DssGov.t.sol
+++ b/src/DssGov.t.sol
@@ -81,8 +81,8 @@ contract GovUser {
         gov.free(wad);
     }
 
-    function doDelegate(address owner, address to) public {
-        gov.delegate(owner, to);
+    function doDelegate(address owner, address to, bool callback) public {
+        gov.delegate(owner, to, callback);
     }
 
     function doPropose(address exec, address action) public returns (uint256 id) {
@@ -139,6 +139,25 @@ contract System {
     }
 }
 
+contract MockL2 {
+    address public gov;
+    mapping(address => uint256) public votes;
+
+    constructor(address _gov) public {
+        gov = _gov;
+    }
+
+    function addDelegation(address owner, uint256 amount) external {
+        require(msg.sender == gov, "");
+        votes[owner] += amount;
+    }
+
+    function delDelegation(address owner, uint256 amount) external {
+        require(msg.sender == gov, "");
+        votes[owner] -= amount;
+    }
+}
+
 contract DssGovTest is DSTest {
     uint256 constant user1InitialBalance = 350000 ether;
     uint256 constant user2InitialBalance = 250000 ether;
@@ -161,6 +180,8 @@ contract DssGovTest is DSTest {
     address action1;
     address action2;
     address action3;
+
+    MockL2 mockL2;
 
     uint256 actualBlock;
 
@@ -200,6 +221,8 @@ contract DssGovTest is DSTest {
         action1 = address(new ActionProposal(address(system)));
         action2 = address(new ActionProposal(address(system)));
         action3 = address(new ActionProposal(address(system)));
+
+        mockL2 = new MockL2(address(gov));
 
         govToken.transfer(address(user1), user1InitialBalance);
         govToken.transfer(address(user2), user2InitialBalance);
@@ -245,7 +268,7 @@ contract DssGovTest is DSTest {
         assertEq(delegate, address(0));
         assertEq(rights, 0);
         user1.doLock(user1InitialBalance);
-        user1.doDelegate(address(user1), address(user2));
+        user1.doDelegate(address(user1), address(user2), false);
         (, delegate,,,,,) = gov.users(address(user1));
         (,, rights,,,,)    = gov.users(address(user2));
         assertEq(delegate, address(user2));
@@ -253,31 +276,31 @@ contract DssGovTest is DSTest {
     }
 
     function test_remove_delegation_delegated() public {
-        user1.doDelegate(address(user1), address(user2));
-        user2.doDelegate(address(user1), address(0));
+        user1.doDelegate(address(user1), address(user2), false);
+        user2.doDelegate(address(user1), address(0), false);
     }
 
     function testFail_change_delegation_delegated() public {
-        user1.doDelegate(address(user1), address(user2));
-        user2.doDelegate(address(user1), address(1));
+        user1.doDelegate(address(user1), address(user2), false);
+        user2.doDelegate(address(user1), address(1), false);
     }
 
     function test_remove_delegation_inactivity() public {
-        user1.doDelegate(address(user1), address(user2));
+        user1.doDelegate(address(user1), address(user2), false);
         _warp(gov.delegationLifetime() / 15 + 1);
-        gov.delegate(address(user1), address(0));
+        gov.delegate(address(user1), address(0), false);
     }
 
     function testFail_remove_delegation_inactivity() public {
-        user1.doDelegate(address(user1), address(user2));
+        user1.doDelegate(address(user1), address(user2), false);
         _warp(gov.delegationLifetime() / 15 - 1);
-        gov.delegate(address(user1), address(0));
+        gov.delegate(address(user1), address(0), false);
     }
 
     function testFail_change_delegation_inactivity() public {
-        user1.doDelegate(address(user1), address(user2));
+        user1.doDelegate(address(user1), address(user2), false);
         _warp(gov.delegationLifetime() / 15 + 1);
-        user2.doDelegate(address(user1), address(1));
+        user2.doDelegate(address(user1), address(1), false);
     }
 
     function test_snapshot() public {
@@ -298,7 +321,7 @@ contract DssGovTest is DSTest {
         assertEq(rights, 0);
 
         _warp(1);
-        user1.doDelegate(address(user1), address(user1));
+        user1.doDelegate(address(user1), address(user1), false);
 
         (,,,,,, numSnapshots) = gov.users(address(user1));
         assertEq(numSnapshots, 2);
@@ -309,7 +332,7 @@ contract DssGovTest is DSTest {
 
     function test_ping() public {
         user1.doLock(user1InitialBalance);
-        user1.doDelegate(address(user1), address(user1));
+        user1.doDelegate(address(user1), address(user1), false);
         (,,, uint256 active,,,) = gov.users(address(user1));
         assertEq(active, 0);
         assertEq(gov.totActive(), 0);
@@ -321,7 +344,7 @@ contract DssGovTest is DSTest {
 
     function test_clear() public {
         user1.doLock(user1InitialBalance);
-        user1.doDelegate(address(user1), address(user1));
+        user1.doDelegate(address(user1), address(user1), false);
         user1.doPing();
          (,,, uint256 active,,,) = gov.users(address(user1));
         assertEq(active, 1);
@@ -345,17 +368,17 @@ contract DssGovTest is DSTest {
         user2.doLock(25000 ether);
         assertTrue(!_tryLaunch());
         user1.doPing();
-        user1.doDelegate(address(user1), address(user1));
+        user1.doDelegate(address(user1), address(user1), false);
         assertTrue(!_tryLaunch());
         user2.doPing();
-        user2.doDelegate(address(user2), address(user2));
+        user2.doDelegate(address(user2), address(user2), false);
         assertTrue(_tryLaunch());
     }
 
     function _launch() internal {
         user1.doLock(100000 ether);
         user1.doPing();
-        user1.doDelegate(address(user1), address(user1));
+        user1.doDelegate(address(user1), address(user1), false);
         gov.launch();
         user1.doFree(100000 ether);
     }
@@ -587,13 +610,13 @@ contract DssGovTest is DSTest {
         assertEq(gov.gasOwners(address(user1), "owner"), 0);
         assertEq(gov.gasOwners(address(user3), "owner"), 0);
         assertEq(gov.gasStorageLength(), 0);
-        user1.doDelegate(address(user1), address(user1));
+        user1.doDelegate(address(user1), address(user1), false);
         assertEq(gov.gasOwners(address(user1), "owner"), 50);
         assertEq(gov.gasStorageLength(), 50);
-        user2.doDelegate(address(user2), address(user2));
+        user2.doDelegate(address(user2), address(user2), false);
         assertEq(gov.gasOwners(address(user2), "owner"), 50);
         assertEq(gov.gasStorageLength(), 100);
-        user3.doDelegate(address(user3), address(user3));
+        user3.doDelegate(address(user3), address(user3), false);
         assertEq(gov.gasOwners(address(user3), "owner"), 50);
         assertEq(gov.gasStorageLength(), 150);
 
@@ -603,14 +626,14 @@ contract DssGovTest is DSTest {
     }
 
     function test_burn_delegation() public {
-        user1.doDelegate(address(user1), address(user1));
-        user2.doDelegate(address(user2), address(user2));
-        user3.doDelegate(address(user3), address(user3));
+        user1.doDelegate(address(user1), address(user1), false);
+        user2.doDelegate(address(user2), address(user2), false);
+        user3.doDelegate(address(user3), address(user3), false);
         assertEq(gov.gasStorageLength(), 150);
         _warp(gov.delegationLifetime() / 15 + 1);
 
         assertEq(gov.gasOwners(address(user3), "owner"), 50);
-        gov.delegate(address(user3), address(0));
+        gov.delegate(address(user3), address(0), false);
         assertEq(gov.gasOwners(address(user3), "owner"), 0);
         assertEq(gov.gasStorageLength(), 100);
 
@@ -673,5 +696,18 @@ contract DssGovTest is DSTest {
         user3.doPropose(exec12, action1);
         user3.doPropose(exec12, action1);
         user3.doPropose(exec12, action1);
+    }
+
+    function test_delegation_callback() public {
+        user1.doLock(10);
+        assertEq(mockL2.votes(address(user1)), 0);
+        user1.doDelegate(address(user1), address(mockL2), true);
+        assertEq(mockL2.votes(address(user1)), 10);
+        user1.doLock(10);
+        assertEq(mockL2.votes(address(user1)), 20);
+        user1.doFree(2);
+        assertEq(mockL2.votes(address(user1)), 18);
+        user1.doDelegate(address(user1), address(0), false);
+        assertEq(mockL2.votes(address(user1)), 0);
     }
 }


### PR DESCRIPTION
This is still another proof of concept which would compete with https://github.com/makerdao/dss-gov/pull/19.

Compared to the other implementation this one is a bit more complex and has to assume the un-delegation succeeds in the callback contract, otherwise might enter in a stuck status.

The positive thing about this solution is it doesn't depend on the implementation of the L2 contract for the user being able to withdraw their MKR. It also avoids one extra thing for governance to manage.

TODO:
- More unit tests
- Possibly adding some reentrancy locks