### PR TITLE
feat: Added Vote Locking

### DIFF
--- a/src/DssGov.sol
+++ b/src/DssGov.sol
@@ -502,7 +502,7 @@ contract DssGov {
         require(wad <= _getUserRights(msg.sender, snapshotIndex, proposals[id].blockNum), "DssGov/amount-exceeds-rights");
 
         // Update locked time
-        users[msg.sender].voteUnlockTime = _max(users[msg.sender].voteUnlockTime, _add(block.timestamp, voteLockDuration));
+        users[msg.sender].voteUnlockTime = _add(block.timestamp, voteLockDuration);
 
         uint256 prev = proposals[id].votes[msg.sender];
         // Update voting rights used by the user

--- a/src/DssGov.sol
+++ b/src/DssGov.sol
@@ -502,7 +502,7 @@ contract DssGov {
         require(wad <= _getUserRights(msg.sender, snapshotIndex, proposals[id].blockNum), "DssGov/amount-exceeds-rights");
 
         // Update locked time
-        users[msg.sender].voteUnlockTime = _add(block.timestamp, voteLockDuration);
+        users[msg.sender].voteUnlockTime = _max(users[msg.sender].voteUnlockTime, _add(block.timestamp, voteLockDuration));
 
         uint256 prev = proposals[id].votes[msg.sender];
         // Update voting rights used by the user

--- a/src/DssGov.sol
+++ b/src/DssGov.sol
@@ -266,7 +266,7 @@ contract DssGov {
         // Get actual delegated address
         address oldDelegated = delegates[owner];
         // Verify it is not trying to set again the actual address
-        require(newDelegated != oldDelegated, "DssGov-already-delegated");
+        require(newDelegated != oldDelegated, "DssGov/already-delegated");
 
         // Verify if the user is authorized to execute this change in delegation
         require(


### PR DESCRIPTION
Added the ability for governance to set a vote locking duration which will only allow calling the `free()` function after the duration has elapsed when voting. Takes into account delegate voting by checking your delegate as well. If you switch your delegate after they vote, the vote locking period will be transferred to your user.

`unlockTime` was split into `voteUnlockTime` and `proposalUnlockTime` because I didn't want voting to block the ability to add another proposal.