### PR TITLE
feat: added IOU token

### DIFF
--- a/src/DssGov.sol
+++ b/src/DssGov.sol
@@ -24,6 +24,11 @@ interface TokenLike {
     function transfer(address, uint256) external;
 }
 
+interface MintableTokenLike {
+    function mint(address, uint256) external;
+    function burn(address, uint256) external;
+}
+
 interface ExecLike {
     function delay() external view returns (uint256);
     function drop(address) external;
@@ -72,6 +77,7 @@ contract DssGov {
     mapping(address => uint256)  public wards;         // Authorized addresses
     uint256                      public live;          // System liveness
     TokenLike                    public govToken;      // MKR gov token
+    MintableTokenLike            public iouToken;      // IOU token
     uint256[]                    public gasStorage;    // Gas storage reserve
     uint256                      public totActive;     // Total active MKR
     uint256                      public numProposals;  // Amount of Proposals
@@ -191,9 +197,10 @@ contract DssGov {
 
 
     /*** Constructor ***/
-    constructor(address govToken_) public {
-        // Assign gov token
+    constructor(address govToken_, address iouToken_) public {
+        // Assign gov and iou tokens
         govToken = TokenLike(govToken_);
+        iouToken = MintableTokenLike(iouToken_);
 
         // Authorize msg.sender
         wards[msg.sender] = 1;
@@ -320,6 +327,9 @@ contract DssGov {
         // Pull MKR from sender's wallet
         govToken.transferFrom(msg.sender, address(this), wad);
 
+        // Mint IOU tokens for the sender
+        iouToken.mint(msg.sender, wad);
+
         // Increase amount deposited from sender
         users[msg.sender].deposit = _add(users[msg.sender].deposit, wad);
 
@@ -345,6 +355,9 @@ contract DssGov {
     function free(uint256 wad) external warm {
         // Check if user has not made recently a proposal
         require(users[msg.sender].unlockTime <= block.timestamp, "DssGov/user-locked");
+
+        // Burn the sender's IOU tokens
+        iouToken.burn(msg.sender, wad);
 
         // Decrease amount deposited from user
         users[msg.sender].deposit = _sub(users[msg.sender].deposit, wad);

--- a/src/DssGov.t.sol
+++ b/src/DssGov.t.sol
@@ -78,6 +78,7 @@ contract GovUser {
     }
 
     function doFree(uint256 wad) public {
+        DSToken(address(gov.iouToken())).approve(address(gov), wad);
         gov.free(wad);
     }
 
@@ -151,6 +152,7 @@ contract DssGovTest is DSTest {
     address exec12;
     address mom;
     DSToken govToken;
+    DSToken iouToken;
 
     GovUser user1;
     GovUser user2;
@@ -172,8 +174,10 @@ contract DssGovTest is DSTest {
         govToken = new DSToken("GOV");
         govToken.mint(1000000 ether);
 
+        iouToken = new DSToken("IOU");
+
         // Gov set up
-        gov = new DssGov(address(govToken));
+        gov = new DssGov(address(govToken), address(iouToken));
         gov.file("rightsLifetime", 30 days);
         gov.file("delegationLifetime", 90 days);
         gov.file("proposalLifetime", 7 days);
@@ -181,6 +185,7 @@ contract DssGovTest is DSTest {
         gov.file("gasStakeAmt", 50); // 50 slots of storage
         gov.file("minGovStake", 1000 ether);
         gov.file("maxProposerAmount", 3);
+        iouToken.setOwner(address(gov));
 
         exec12 = address(new GovExec(address(gov), 12 hours));
         exec0 = address(new GovExec(address(gov), 0));


### PR DESCRIPTION
Token implementation is flexible. It just needs to provide `mint()` and `burn()` functions. I've used a DSToken as an example, but we could also consider modifying DSToken to give a permanent approval to `gov`.