### PR TITLE
Added revokable delegate token

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/ds-token"]
 	path = lib/ds-token
 	url = https://github.com/makerdao/ds-token
+[submodule "lib/zeppelin-solidity"]
+	path = lib/zeppelin-solidity
+	url = https://github.com/OpenZeppelin/zeppelin-solidity

--- a/src/RevokableNFT.sol
+++ b/src/RevokableNFT.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// RevokableNFT.sol
+
+// Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.6.7;
+
+// An NFT which allows authed users to be able to revoke the token.
+// Follows the ERC721 standard.
+contract RevokableNFT {
+
+    /*** Events ***/
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+
+    /*** Auth ***/
+    function rely(address usr) external auth { wards[usr] = 1; emit Rely(usr); }
+    function deny(address usr) external auth { wards[usr] = 0; emit Deny(usr); }
+    modifier auth { require(wards[msg.sender] == 1, "RevokableNFT/not-authorized"); _; }
+
+    constructor(string name_, string symbol_) {
+        // Authorize msg.sender
+        wards[msg.sender] = 1;
+
+        // Emit event
+        emit Rely(msg.sender);
+    }
+
+}


### PR DESCRIPTION
This will allow delegates to insert this token into other contracts to prove that they having a certain amount of MKR being under their voting control. There are many future use cases for this.

There is an optional callback to any contract when the token is forcibly revoked to keep external accounting up to date.

This could probably be used for active MKR as well.

Note: we should probably put a reentrancy lock on DssGov delegation as well just to be safe.