### PR TITLE
Not allow to vote when the user's voting rights changed in the same b…

### DIFF
--- a/src/DssGov.sol
+++ b/src/DssGov.sol
@@ -195,7 +195,7 @@ contract DssGov {
         require(num >= index, "DssGov/not-existing-index");
         Snapshot memory snapshot = users[usr].snapshots[index];
         require(snapshot.fromBlock < blockNum, "DssGov/not-correct-snapshot-1"); // "<" protects for flash loans on voting
-        require(index == num || users[usr].snapshots[index + 1].fromBlock >= blockNum, "DssGov/not-correct-snapshot-2");
+        require(index == num || users[usr].snapshots[index + 1].fromBlock > blockNum, "DssGov/not-correct-snapshot-2");
 
         amount = snapshot.rights;
     }


### PR DESCRIPTION
…lock of the proposal

This situation was reported by Certora:

"_We had some time to analyze the DssGov contract and we found a potential issue. We are not sure what is the current deployment status of this contract, but we thought it would be best to inform you as soon as possible.

The issue is about the correctness of the total active votes (totActive) at the time of proposal submission. We expect this value to be exactly equal to the total number of possible votes that this proposal can get (In formal terms we assume that proposals[id].totVotes<=proposals[id].totActive). However, this constraint can be violated if a user (who has some rights) would call clear() before the proposal submission, but in the same block. This is because that user would still be able to vote with the rights of the snapshot from before the clear (because of the ">=" inequality in "users[usr].snapshots[index + 1].fromBlock >= blockNum"), but "totActive" at the time of proposal would of course not include them. In other words, in such a case it is possible to get more than a 100% voting rate for that proposal.

In a possible scenario, a malicious user with 37.5% of all active votes would be able to single-handedly pass a proposal with a 60% threshold using this method (0.375/(1-0.375)=0.6).

A possible mitigation would be to make the inequality in _getUserRights() strict._"

As a note we can say that this issue won't only happen with `clear` but also with `delegate`, as a MKR owner can remove voting power from their delegated to `address(0)` right before a proposal is created in the same block, that will effectively also change the amount of `totActive`. Same issue.

The mentioned solution (and committed in this PR) brings 2 other issues, one minor and one more important:

- Minor: the opposite case might happen. A proposal is created right before someone is cleared in the same block.
Then the `totActive` will count the rights of this person but who won't be able to vote.

- More problematic: Denial of voting attack. As now a voter can't participate in proposals which have been created in a block which the user has a snapshot, someone could just keep spamming other delegating and undelegating any amount of MKR. That will be prevent that person from voting. The only possible solution I see for now is making the delegated person has to accept for having a new snapshot when MKR is added.
